### PR TITLE
Max Concurrent Routines Cap

### DIFF
--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/nightfallai/nightfall_cli/internal/clients/nightfall"
+
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_cli/internal/clients/diffreviewer"
 	"github.com/nightfallai/nightfall_cli/internal/clients/logger"
@@ -187,10 +189,16 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 		s.Logger.Error(fmt.Sprintf("Error getting Nightfall API key. Ensure you have %s set in the Github secrets of the repo", NightfallAPIKeyEnvVar))
 		return nil, errors.New("Missing env var for nightfall api key")
 	}
+	var maxNumberRoutines int
+	if nightfallConfig.MaxNumberRoutines < nightfall.MaxConcurrentRoutinesCap {
+		maxNumberRoutines = nightfallConfig.MaxNumberRoutines
+	} else {
+		maxNumberRoutines = nightfall.MaxConcurrentRoutinesCap
+	}
 	return &nightfallconfig.Config{
 		NightfallAPIKey:            nightfallAPIKey,
 		NightfallDetectors:         nightfallConfig.Detectors,
-		NightfallMaxNumberRoutines: nightfallConfig.MaxNumberRoutines,
+		NightfallMaxNumberRoutines: maxNumberRoutines,
 		TokenExclusionList:         nightfallConfig.TokenExclusionList,
 		FileInclusionList:          nightfallConfig.FileInclusionList,
 		FileExclusionList:          nightfallConfig.FileExclusionList,

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -11,12 +11,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nightfallai/nightfall_cli/internal/clients/nightfall"
-
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_cli/internal/clients/diffreviewer"
 	"github.com/nightfallai/nightfall_cli/internal/clients/logger"
 	githublogger "github.com/nightfallai/nightfall_cli/internal/clients/logger/github_logger"
+	"github.com/nightfallai/nightfall_cli/internal/clients/nightfall"
 	"github.com/nightfallai/nightfall_cli/internal/interfaces/githubintf"
 	"github.com/nightfallai/nightfall_cli/internal/nightfallconfig"
 )

--- a/internal/clients/nightfall/nightfall.go
+++ b/internal/clients/nightfall/nightfall.go
@@ -28,7 +28,8 @@ const (
 	// max number of items that can be sent to Nightfall API at a time
 	maxItemsForAPIReq = 479
 
-	defaultTimeout = time.Minute * 20
+	defaultTimeout           = time.Minute * 20
+	MaxConcurrentRoutinesCap = 50
 )
 
 // likelihoodThresholdMap gives each likelihood an integer value representation


### PR DESCRIPTION
(Arbitrarily) adding a maximum to the max concurrent routines cap in case customers configure a high number.

Currently set to 50, but definitely will be variable to change when we look into the overall rate limiting issues we're experiencing