### PR TITLE
NIGH-153 Fix FilterComments Error

### DIFF
--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -281,18 +281,18 @@ func filterExistingComments(comments []*github.PullRequestComment, existingComme
 	existingCommentsMap := make(map[prComment]bool, len(existingComments))
 	for _, ec := range existingComments {
 		comment := prComment{
-			Body: *ec.Body,
-			Path: *ec.Path,
-			Line: *ec.Line,
+			Body: ec.GetBody(),
+			Path: ec.GetPath(),
+			Line: ec.GetLine(),
 		}
 		existingCommentsMap[comment] = true
 	}
 	filteredComments := make([]*github.PullRequestComment, 0, len(comments))
 	for _, c := range comments {
 		comment := prComment{
-			Body: *c.Body,
-			Path: *c.Path,
-			Line: *c.Line,
+			Body: c.GetBody(),
+			Path: c.GetPath(),
+			Line: c.GetLine(),
 		}
 		if _, ok := existingCommentsMap[comment]; !ok {
 			filteredComments = append(filteredComments, c)

--- a/internal/clients/diffreviewer/circleci/circleci_service_test.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service_test.go
@@ -444,6 +444,11 @@ func (c *circleCiTestSuite) TestFilterExistingComments() {
 			Path: &pathStrs[2],
 			Line: &lineNums[2],
 		},
+		{
+			Body: &bodyStrs[0],
+			Path: &pathStrs[0],
+			Line: nil,
+		},
 	}
 	newComment1 := &github.PullRequestComment{
 		Body: &bodyStrs[0],


### PR DESCRIPTION
`ec(github.PullRequestComment).Line` does not exist for outdated comments, which was causing an nil dereference error, but `ec.GetLine()` will return 0 if it does not exist.