### PR TITLE
NIGH-154 Default Config

### DIFF
--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -8,8 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
-
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/diffutils"
@@ -21,6 +19,7 @@ import (
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/gitdiffintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/githubintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/nightfallconfig"
+	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 )
 
 const (

--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/gitdiffintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/githubintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/nightfallconfig"
-	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 )
 
 const (
@@ -41,8 +40,6 @@ const (
 )
 
 var errSensitiveItemsFound = errors.New("potentially sensitive items found")
-var apiKeyDetector = nightfallAPI.API_KEY
-var cryptoKeyDetector = nightfallAPI.CRYPTOGRAPHIC_TOKEN
 
 // Service contains the github client that makes Github api calls
 type Service struct {

--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/gitdiff"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/logger"
 	circlelogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/circle_logger"
-	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/gitdiffintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/githubintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/nightfallconfig"
@@ -106,17 +105,10 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 		s.Logger.Error(fmt.Sprintf("Error getting Nightfall API key. Ensure you have %s set in the Github secrets of the repo", NightfallAPIKeyEnvVar))
 		return nil, errors.New("missing env var for nightfall api key")
 	}
-
-	var maxNumberRoutines int
-	if nightfallConfig.MaxNumberRoutines < nightfall.MaxConcurrentRoutinesCap {
-		maxNumberRoutines = nightfallConfig.MaxNumberRoutines
-	} else {
-		maxNumberRoutines = nightfallconfig.DefaultMaxNumberRoutines
-	}
 	return &nightfallconfig.Config{
 		NightfallAPIKey:            nightfallAPIKey,
 		NightfallDetectors:         nightfallConfig.Detectors,
-		NightfallMaxNumberRoutines: maxNumberRoutines,
+		NightfallMaxNumberRoutines: nightfallConfig.MaxNumberRoutines,
 		TokenExclusionList:         nightfallConfig.TokenExclusionList,
 		FileInclusionList:          nightfallConfig.FileInclusionList,
 		FileExclusionList:          nightfallConfig.FileExclusionList,

--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -111,10 +111,10 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 	}
 
 	var maxNumberRoutines int
-	if nightfallConfig.MaxNumberRoutines < nightfall.MaxConcurrentRoutinesCap && nightfallConfig.MaxNumberRoutines > 0 {
+	if nightfallConfig.MaxNumberRoutines < nightfall.MaxConcurrentRoutinesCap {
 		maxNumberRoutines = nightfallConfig.MaxNumberRoutines
 	} else {
-		maxNumberRoutines = nightfall.MaxConcurrentRoutinesCap
+		maxNumberRoutines = nightfallconfig.DefaultMaxNumberRoutines
 	}
 	return &nightfallconfig.Config{
 		NightfallAPIKey:            nightfallAPIKey,

--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -103,13 +103,7 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 		BaseSHA:    beforeCommitSha,
 		Head:       s.PrDetails.CommitSha,
 	}
-	nightfallConfig, err := nightfallconfig.GetNightfallConfigFile(workspacePath, nightfallConfigFileName)
-	if err != nil {
-		s.Logger.Warning("Issue retrieving valid Nightfall config file, using default detectors instead. Ensure you have a Nightfall config file located in the root of your repository at .nightfalldlp/config.json with at least one Detector enabled")
-		nightfallConfig = &nightfallconfig.NightfallConfigFileStructure{
-			Detectors: []*nightfallAPI.Detector{&apiKeyDetector, &cryptoKeyDetector},
-		}
-	}
+	nightfallConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, nightfallConfigFileName, s.Logger)
 	nightfallAPIKey, ok := os.LookupEnv(NightfallAPIKeyEnvVar)
 	if !ok || nightfallAPIKey == "" {
 		s.Logger.Error(fmt.Sprintf("Error getting Nightfall API key. Ensure you have %s set in the Github secrets of the repo", NightfallAPIKeyEnvVar))

--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -99,7 +99,11 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 		BaseSHA:    beforeCommitSha,
 		Head:       s.PrDetails.CommitSha,
 	}
-	nightfallConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, nightfallConfigFileName, s.Logger)
+	nightfallConfig, err := nightfallconfig.GetNightfallConfigFile(workspacePath, nightfallConfigFileName, s.Logger)
+	if err != nil {
+		s.Logger.Error("Error getting Nightfall config file. Ensure you have a Nightfall config file located in the root of your repository at .nightfalldlp/config.json with at least one Detector enabled")
+		return nil, err
+	}
 	nightfallAPIKey, ok := os.LookupEnv(NightfallAPIKeyEnvVar)
 	if !ok || nightfallAPIKey == "" {
 		s.Logger.Error(fmt.Sprintf("Error getting Nightfall API key. Ensure you have %s set in the Github secrets of the repo", NightfallAPIKeyEnvVar))

--- a/internal/clients/diffreviewer/circleci/circleci_service_test.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service_test.go
@@ -8,6 +8,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
+
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
@@ -137,6 +139,7 @@ const testOwner = "alan20854"
 const testRepo = "TestRepo"
 const testPrUrl = "https://github.com/alan20854/CircleCiTest/pull/3"
 const testConfigFileName = "nightfall_test_config.json"
+const testEmptyConfigFileName = "nightfall_empty_test_config.json"
 const excludedCreditCardRegex = "4242-4242-4242-[0-9]{4}"
 const excludedApiToken = "xG0Ct4Wsu3OTcJnE1dFLAQfRgL6b8tIv"
 const excludedIPRegex = "^127\\."
@@ -209,6 +212,34 @@ func (c *circleCiTestSuite) TestLoadConfigMissingApiKey() {
 		"missing env var for nightfall api key",
 		"incorrect error from missing api key test",
 	)
+}
+
+func (c *circleCiTestSuite) TestLoadEmptyConfig() {
+	tp := c.initTestParams()
+	apiKey := "api-key"
+	apiDetector := nightfallAPI.API_KEY
+	cryptoDetector := nightfallAPI.CRYPTOGRAPHIC_TOKEN
+	workspace, err := os.Getwd()
+	c.NoError(err, "Error getting workspace")
+	workspacePath := path.Join(workspace, "../../../../test/data")
+	os.Setenv(WorkspacePathEnvVar, workspacePath)
+	os.Setenv(CircleCurrentCommitShaEnvVar, commitSha)
+	os.Setenv(CircleBeforeCommitEnvVar, prevCommitSha)
+	os.Setenv(CircleBranchEnvVar, testBranch)
+	os.Setenv(CircleOwnerNameEnvVar, testOwner)
+	os.Setenv(CircleRepoNameEnvVar, testRepo)
+	os.Setenv(CirclePullRequestUrlEnvVar, testPrUrl)
+	os.Setenv(NightfallAPIKeyEnvVar, apiKey)
+
+	expectedNightfallConfig := &nightfallconfig.Config{
+		NightfallAPIKey:            apiKey,
+		NightfallDetectors:         []*nightfallAPI.Detector{&apiDetector, &cryptoDetector},
+		NightfallMaxNumberRoutines: nightfall.MaxConcurrentRoutinesCap,
+	}
+
+	nightfallConfig, err := tp.cs.LoadConfig(testEmptyConfigFileName)
+	c.NoError(err, "Error in LoadConfig")
+	c.Equal(expectedNightfallConfig, nightfallConfig, "Incorrect nightfall config")
 }
 
 func (c *circleCiTestSuite) TestGetDiff() {

--- a/internal/clients/diffreviewer/circleci/circleci_service_test.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	circlelogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/circle_logger"
-	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/gitdiff_mock"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/githubclient_mock"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/githubpullrequests_mock"
@@ -233,11 +232,11 @@ func (c *circleCiTestSuite) TestLoadEmptyConfig() {
 	expectedNightfallConfig := &nightfallconfig.Config{
 		NightfallAPIKey:            apiKey,
 		NightfallDetectors:         []*nightfallAPI.Detector{&apiDetector, &cryptoDetector},
-		NightfallMaxNumberRoutines: nightfall.MaxConcurrentRoutinesCap,
+		NightfallMaxNumberRoutines: 20,
 	}
 
 	nightfallConfig, err := tp.cs.LoadConfig(testEmptyConfigFileName)
-	c.NoError(err, "Error in LoadConfig")
+	c.NoError(err, "Unexpected error in LoadConfig")
 	c.Equal(expectedNightfallConfig, nightfallConfig, "Incorrect nightfall config")
 }
 

--- a/internal/clients/diffreviewer/circleci/circleci_service_test.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service_test.go
@@ -188,7 +188,7 @@ func (c *circleCiTestSuite) TestLoadConfig() {
 	}
 
 	nightfallConfig, err := tp.cs.LoadConfig(testConfigFileName)
-	c.NoError(err, "Error in LoadConfig")
+	c.NoError(err, "Unexpected error in LoadConfig")
 	c.Equal(expectedNightfallConfig, nightfallConfig, "Incorrect nightfall config")
 }
 

--- a/internal/clients/diffreviewer/circleci/circleci_service_test.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service_test.go
@@ -8,12 +8,11 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
-
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	circlelogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/circle_logger"
+	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/gitdiff_mock"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/githubclient_mock"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/githubpullrequests_mock"

--- a/internal/clients/diffreviewer/circleci/circleci_service_test.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service_test.go
@@ -232,7 +232,7 @@ func (c *circleCiTestSuite) TestLoadEmptyConfig() {
 	expectedNightfallConfig := &nightfallconfig.Config{
 		NightfallAPIKey:            apiKey,
 		NightfallDetectors:         []*nightfallAPI.Detector{&apiDetector, &cryptoDetector},
-		NightfallMaxNumberRoutines: 20,
+		NightfallMaxNumberRoutines: nightfallconfig.DefaultMaxNumberRoutines,
 	}
 
 	nightfallConfig, err := tp.cs.LoadConfig(testEmptyConfigFileName)

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/gitdiff"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/logger"
 	githublogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/github_logger"
-	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/gitdiffintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/githubintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/nightfallconfig"
@@ -194,16 +193,10 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 		s.Logger.Error(fmt.Sprintf("Error getting Nightfall API key. Ensure you have %s set in the Github secrets of the repo", NightfallAPIKeyEnvVar))
 		return nil, errors.New("Missing env var for nightfall api key")
 	}
-	var maxNumberRoutines int
-	if nightfallConfig.MaxNumberRoutines < nightfall.MaxConcurrentRoutinesCap {
-		maxNumberRoutines = nightfallConfig.MaxNumberRoutines
-	} else {
-		maxNumberRoutines = nightfallconfig.DefaultMaxNumberRoutines
-	}
 	return &nightfallconfig.Config{
 		NightfallAPIKey:            nightfallAPIKey,
 		NightfallDetectors:         nightfallConfig.Detectors,
-		NightfallMaxNumberRoutines: maxNumberRoutines,
+		NightfallMaxNumberRoutines: nightfallConfig.MaxNumberRoutines,
 		TokenExclusionList:         nightfallConfig.TokenExclusionList,
 		FileInclusionList:          nightfallConfig.FileInclusionList,
 		FileExclusionList:          nightfallConfig.FileExclusionList,

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -19,7 +19,6 @@ import (
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/gitdiffintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/githubintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/nightfallconfig"
-	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 )
 
 type Level string
@@ -45,9 +44,6 @@ var checkRunCompletedStatus = "completed"
 var checkRunInProgressStatus = "in_progress"
 var checkRunConclusionSuccess = "success"
 var checkRunConclusionFailure = "failure"
-
-var apiKeyDetector = nightfallAPI.API_KEY
-var cryptoKeyDetector = nightfallAPI.CRYPTOGRAPHIC_TOKEN
 
 type ownerLogin struct {
 	Login string `json:"login"`

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -187,7 +187,11 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 		BaseSHA:    event.Before,
 		Head:       s.CheckRequest.SHA,
 	}
-	nightfallConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, nightfallConfigFileName, s.Logger)
+	nightfallConfig, err := nightfallconfig.GetNightfallConfigFile(workspacePath, nightfallConfigFileName, s.Logger)
+	if err != nil {
+		s.Logger.Error("Error getting Nightfall config file. Ensure you have a Nightfall config file located in the root of your repository at .nightfalldlp/config.json with at least one Detector enabled")
+		return nil, err
+	}
 	nightfallAPIKey, ok := os.LookupEnv(NightfallAPIKeyEnvVar)
 	if !ok || nightfallAPIKey == "" {
 		s.Logger.Error(fmt.Sprintf("Error getting Nightfall API key. Ensure you have %s set in the Github secrets of the repo", NightfallAPIKeyEnvVar))

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -9,12 +9,9 @@ import (
 	"os"
 	"strings"
 
-	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
-
-	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/diffutils"
-
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
+	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/diffutils"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/gitdiff"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/logger"
 	githublogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/github_logger"
@@ -22,6 +19,7 @@ import (
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/gitdiffintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/githubintf"
 	"github.com/nightfallai/nightfall_code_scanner/internal/nightfallconfig"
+	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 )
 
 type Level string

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -192,13 +192,7 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 		BaseSHA:    event.Before,
 		Head:       s.CheckRequest.SHA,
 	}
-	nightfallConfig, err := nightfallconfig.GetNightfallConfigFile(workspacePath, nightfallConfigFileName)
-	if err != nil {
-		s.Logger.Warning("Issue retrieving valid Nightfall config file, using default detectors instead. Ensure you have a Nightfall config file located in the root of your repository at .nightfalldlp/config.json with at least one Detector enabled")
-		nightfallConfig = &nightfallconfig.NightfallConfigFileStructure{
-			Detectors: []*nightfallAPI.Detector{&apiKeyDetector, &cryptoKeyDetector},
-		}
-	}
+	nightfallConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, nightfallConfigFileName, s.Logger)
 	nightfallAPIKey, ok := os.LookupEnv(NightfallAPIKeyEnvVar)
 	if !ok || nightfallAPIKey == "" {
 		s.Logger.Error(fmt.Sprintf("Error getting Nightfall API key. Ensure you have %s set in the Github secrets of the repo", NightfallAPIKeyEnvVar))

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -199,10 +199,10 @@ func (s *Service) LoadConfig(nightfallConfigFileName string) (*nightfallconfig.C
 		return nil, errors.New("Missing env var for nightfall api key")
 	}
 	var maxNumberRoutines int
-	if nightfallConfig.MaxNumberRoutines < nightfall.MaxConcurrentRoutinesCap && nightfallConfig.MaxNumberRoutines > 0 {
+	if nightfallConfig.MaxNumberRoutines < nightfall.MaxConcurrentRoutinesCap {
 		maxNumberRoutines = nightfallConfig.MaxNumberRoutines
 	} else {
-		maxNumberRoutines = nightfall.MaxConcurrentRoutinesCap
+		maxNumberRoutines = nightfallconfig.DefaultMaxNumberRoutines
 	}
 	return &nightfallconfig.Config{
 		NightfallAPIKey:            nightfallAPIKey,

--- a/internal/clients/diffreviewer/github/github_service_test.go
+++ b/internal/clients/diffreviewer/github/github_service_test.go
@@ -9,13 +9,12 @@ import (
 	"path"
 	"testing"
 
-	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
-
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	githubservice "github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/github"
 	githublogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/github_logger"
+	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/gitdiff_mock"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/githubchecks_mock"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/githubclient_mock"

--- a/internal/clients/diffreviewer/github/github_service_test.go
+++ b/internal/clients/diffreviewer/github/github_service_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	githubservice "github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/github"
 	githublogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/github_logger"
-	"github.com/nightfallai/nightfall_code_scanner/internal/clients/nightfall"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/gitdiff_mock"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/githubchecks_mock"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/githubclient_mock"
@@ -216,7 +215,7 @@ func (g *githubTestSuite) TestLoadEmptyConfig() {
 	expectedNightfallConfig := &nightfallconfig.Config{
 		NightfallAPIKey:            apiKey,
 		NightfallDetectors:         []*nightfallAPI.Detector{&apiDetector, &cryptoDetector},
-		NightfallMaxNumberRoutines: nightfall.MaxConcurrentRoutinesCap,
+		NightfallMaxNumberRoutines: 20,
 	}
 	expectedGithubCheckRequest := &githubservice.CheckRequest{
 		Owner:       owner,

--- a/internal/clients/diffreviewer/github/github_service_test.go
+++ b/internal/clients/diffreviewer/github/github_service_test.go
@@ -190,9 +190,9 @@ func (g *githubTestSuite) TestLoadConfig() {
 	}
 
 	nightfallConfig, err := tp.gc.LoadConfig(testConfigFileName)
-	g.NoError(err, "Error in LoadConfig")
+	g.NoError(err, "Unexpected error in LoadConfig")
 	g.Equal(expectedNightfallConfig, nightfallConfig, "Incorrect nightfall config")
-	g.Equal(expectedGithubCheckRequest, tp.gc.CheckRequest, "Incorrect nightfall config")
+	g.Equal(expectedGithubCheckRequest, tp.gc.CheckRequest, "Incorrect github check request")
 }
 
 func (g *githubTestSuite) TestLoadEmptyConfig() {
@@ -225,9 +225,9 @@ func (g *githubTestSuite) TestLoadEmptyConfig() {
 	}
 
 	nightfallConfig, err := tp.gc.LoadConfig(testEmptyConfigFileName)
-	g.NoError(err, "Error in LoadConfig")
+	g.NoError(err, "Unexpected error in LoadConfig")
 	g.Equal(expectedNightfallConfig, nightfallConfig, "Incorrect nightfall config")
-	g.Equal(expectedGithubCheckRequest, tp.gc.CheckRequest, "Incorrect nightfall config")
+	g.Equal(expectedGithubCheckRequest, tp.gc.CheckRequest, "Incorrect github check request")
 }
 
 func (g *githubTestSuite) TestGetDiff() {

--- a/internal/clients/diffreviewer/github/github_service_test.go
+++ b/internal/clients/diffreviewer/github/github_service_test.go
@@ -215,7 +215,7 @@ func (g *githubTestSuite) TestLoadEmptyConfig() {
 	expectedNightfallConfig := &nightfallconfig.Config{
 		NightfallAPIKey:            apiKey,
 		NightfallDetectors:         []*nightfallAPI.Detector{&apiDetector, &cryptoDetector},
-		NightfallMaxNumberRoutines: 20,
+		NightfallMaxNumberRoutines: nightfallconfig.DefaultMaxNumberRoutines,
 	}
 	expectedGithubCheckRequest := &githubservice.CheckRequest{
 		Owner:       owner,

--- a/internal/clients/nightfall/nightfall.go
+++ b/internal/clients/nightfall/nightfall.go
@@ -31,8 +31,6 @@ const (
 	maxItemsForAPIReq = 479
 	// timeout for the total time spent sending scan requests and receiving responses for a diff
 	defaultTimeout = time.Minute * 20
-	// maximum number of routines (scan request + response) running at once
-	MaxConcurrentRoutinesCap = 50
 	// maximum attempts to Nightfall API upon receiving 429 Too Many Requests before failing
 	MaxScanAttempts = 5
 	// initial delay before re-attempting scan request

--- a/internal/nightfallconfig/nightfall_config.go
+++ b/internal/nightfallconfig/nightfall_config.go
@@ -2,16 +2,21 @@ package nightfallconfig
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 
+	"github.com/nightfallai/nightfall_code_scanner/internal/clients/logger"
+
 	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 )
 
-const defaultMaxNumberRoutines = 30
+const defaultMaxNumberRoutines = 20
 const nightfallConfigFilename = ".nightfalldlp/config.json"
+
+var apiKeyDetector = nightfallAPI.API_KEY
+var cryptoKeyDetector = nightfallAPI.CRYPTOGRAPHIC_TOKEN
 
 // NightfallConfigFileStructure struct representation of nightfall config file
 type NightfallConfigFileStructure struct {
@@ -32,28 +37,40 @@ type Config struct {
 	FileExclusionList          []string
 }
 
-// GetNightfallConfigFile loads nightfall config from file
-func GetNightfallConfigFile(workspacePath, fileName string) (*NightfallConfigFileStructure, error) {
+// GetNightfallConfigFile loads nightfall config from file, returns default if missing/invalid
+func GetNightfallConfigFile(workspacePath, fileName string, logger logger.Logger) *NightfallConfigFileStructure {
+	defaultNightfallConfig := &NightfallConfigFileStructure{
+		Detectors:         []*nightfallAPI.Detector{&apiKeyDetector, &cryptoKeyDetector},
+		MaxNumberRoutines: defaultMaxNumberRoutines,
+	}
 	nightfallConfigFile, err := os.Open(path.Join(workspacePath, fileName))
 	if err != nil {
-		return nil, err
+		logger.Warning(fmt.Sprintf("Error opening nightfall config: %s", err.Error()))
+		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
+		return defaultNightfallConfig
 	}
 	defer nightfallConfigFile.Close()
 	byteValue, err := ioutil.ReadAll(nightfallConfigFile)
 	if err != nil {
-		return nil, err
+		logger.Warning(fmt.Sprintf("Error reading nightfall config: %s", err.Error()))
+		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
+		return defaultNightfallConfig
 	}
 	var nightfallConfig NightfallConfigFileStructure
 	err = json.Unmarshal(byteValue, &nightfallConfig)
 	if err != nil {
-		return nil, err
+		logger.Warning("Invalid nightfall config")
+		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
+		return defaultNightfallConfig
 	}
 	if len(nightfallConfig.Detectors) < 1 {
-		return nil, errors.New("Nightfall config file is missing detectors")
+		logger.Warning("Nightfall config requires at least one detector")
+		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
+		return defaultNightfallConfig
 	}
 	if nightfallConfig.MaxNumberRoutines == 0 {
 		nightfallConfig.MaxNumberRoutines = defaultMaxNumberRoutines
 	}
 	nightfallConfig.FileExclusionList = append(nightfallConfig.FileExclusionList, nightfallConfigFilename)
-	return &nightfallConfig, nil
+	return &nightfallConfig
 }

--- a/internal/nightfallconfig/nightfall_config.go
+++ b/internal/nightfallconfig/nightfall_config.go
@@ -62,13 +62,9 @@ func GetNightfallConfigFile(workspacePath, fileName string, logger logger.Logger
 	var nightfallConfig NightfallConfigFileStructure
 	err = json.Unmarshal(byteValue, &nightfallConfig)
 	if err != nil {
-		logger.Warning("Invalid nightfall config")
-		logger.Info(defaultDetectorsInfoMessage)
 		return nil, err
 	}
 	if len(nightfallConfig.Detectors) < 1 {
-		logger.Warning("Nightfall config requires at least one detector")
-		logger.Info(defaultDetectorsInfoMessage)
 		return nil, errors.New("Nightfall config file is missing detectors")
 	}
 	if nightfallConfig.MaxNumberRoutines <= 0 {

--- a/internal/nightfallconfig/nightfall_config.go
+++ b/internal/nightfallconfig/nightfall_config.go
@@ -11,6 +11,8 @@ import (
 	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 )
 
+// maximum number of routines (scan request + response) running at once
+const MaxConcurrentRoutinesCap = 50
 const DefaultMaxNumberRoutines = 20
 const nightfallConfigFilename = ".nightfalldlp/config.json"
 const defaultDetectorsInfoMessage = "Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)"
@@ -68,7 +70,7 @@ func GetNightfallConfigFile(workspacePath, fileName string, logger logger.Logger
 		logger.Info(defaultDetectorsInfoMessage)
 		return defaultNightfallConfig
 	}
-	if nightfallConfig.MaxNumberRoutines <= 0 {
+	if nightfallConfig.MaxNumberRoutines > MaxConcurrentRoutinesCap || nightfallConfig.MaxNumberRoutines <= 0 {
 		nightfallConfig.MaxNumberRoutines = DefaultMaxNumberRoutines
 	}
 	nightfallConfig.FileExclusionList = append(nightfallConfig.FileExclusionList, nightfallConfigFilename)

--- a/internal/nightfallconfig/nightfall_config.go
+++ b/internal/nightfallconfig/nightfall_config.go
@@ -8,12 +8,12 @@ import (
 	"path"
 
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/logger"
-
 	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 )
 
 const DefaultMaxNumberRoutines = 20
 const nightfallConfigFilename = ".nightfalldlp/config.json"
+const defaultDetectorsInfoMessage = "Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)"
 
 var apiKeyDetector = nightfallAPI.API_KEY
 var cryptoKeyDetector = nightfallAPI.CRYPTOGRAPHIC_TOKEN
@@ -46,26 +46,26 @@ func GetNightfallConfigFile(workspacePath, fileName string, logger logger.Logger
 	nightfallConfigFile, err := os.Open(path.Join(workspacePath, fileName))
 	if err != nil {
 		logger.Warning(fmt.Sprintf("Error opening nightfall config: %s", err.Error()))
-		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
+		logger.Info(defaultDetectorsInfoMessage)
 		return defaultNightfallConfig
 	}
 	defer nightfallConfigFile.Close()
 	byteValue, err := ioutil.ReadAll(nightfallConfigFile)
 	if err != nil {
 		logger.Warning(fmt.Sprintf("Error reading nightfall config: %s", err.Error()))
-		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
+		logger.Info(defaultDetectorsInfoMessage)
 		return defaultNightfallConfig
 	}
 	var nightfallConfig NightfallConfigFileStructure
 	err = json.Unmarshal(byteValue, &nightfallConfig)
 	if err != nil {
 		logger.Warning("Invalid nightfall config")
-		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
+		logger.Info(defaultDetectorsInfoMessage)
 		return defaultNightfallConfig
 	}
 	if len(nightfallConfig.Detectors) < 1 {
 		logger.Warning("Nightfall config requires at least one detector")
-		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
+		logger.Info(defaultDetectorsInfoMessage)
 		return defaultNightfallConfig
 	}
 	if nightfallConfig.MaxNumberRoutines <= 0 {

--- a/internal/nightfallconfig/nightfall_config.go
+++ b/internal/nightfallconfig/nightfall_config.go
@@ -12,7 +12,7 @@ import (
 	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 )
 
-const defaultMaxNumberRoutines = 20
+const DefaultMaxNumberRoutines = 20
 const nightfallConfigFilename = ".nightfalldlp/config.json"
 
 var apiKeyDetector = nightfallAPI.API_KEY
@@ -41,7 +41,7 @@ type Config struct {
 func GetNightfallConfigFile(workspacePath, fileName string, logger logger.Logger) *NightfallConfigFileStructure {
 	defaultNightfallConfig := &NightfallConfigFileStructure{
 		Detectors:         []*nightfallAPI.Detector{&apiKeyDetector, &cryptoKeyDetector},
-		MaxNumberRoutines: defaultMaxNumberRoutines,
+		MaxNumberRoutines: DefaultMaxNumberRoutines,
 	}
 	nightfallConfigFile, err := os.Open(path.Join(workspacePath, fileName))
 	if err != nil {
@@ -68,8 +68,8 @@ func GetNightfallConfigFile(workspacePath, fileName string, logger logger.Logger
 		logger.Info("Using default detectors (API_KEY and CRYTOGRAPHIC_TOKEN)")
 		return defaultNightfallConfig
 	}
-	if nightfallConfig.MaxNumberRoutines == 0 {
-		nightfallConfig.MaxNumberRoutines = defaultMaxNumberRoutines
+	if nightfallConfig.MaxNumberRoutines <= 0 {
+		nightfallConfig.MaxNumberRoutines = DefaultMaxNumberRoutines
 	}
 	nightfallConfig.FileExclusionList = append(nightfallConfig.FileExclusionList, nightfallConfigFilename)
 	return &nightfallConfig

--- a/internal/nightfallconfig/nightfall_config_test.go
+++ b/internal/nightfallconfig/nightfall_config_test.go
@@ -5,12 +5,15 @@ import (
 	"path"
 	"testing"
 
+	githublogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/github_logger"
+
 	"github.com/nightfallai/nightfall_code_scanner/internal/nightfallconfig"
 	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 	"github.com/stretchr/testify/assert"
 )
 
 const testFileName = "nightfall_test_config.json"
+const testMissingFileName = "nightfall_test_missing_config.json"
 const excludedCreditCardRegex = "4242-4242-4242-[0-9]{4}"
 const excludedApiToken = "xG0Ct4Wsu3OTcJnE1dFLAQfRgL6b8tIv"
 const excludedIPRegex = "^127\\."
@@ -29,7 +32,20 @@ func TestGetNightfallConfig(t *testing.T) {
 		FileInclusionList:  []string{"*"},
 		FileExclusionList:  []string{".nightfalldlp/config.json"},
 	}
-	actualConfig, err := nightfallconfig.GetNightfallConfigFile(workspacePath, testFileName)
-	assert.NoError(t, err, "Unexpected error when GetNightfallConfig")
+	actualConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, testFileName, nil)
+	assert.Equal(t, expectedConfig, actualConfig, "Incorrect nightfall config")
+}
+
+func TestGetNightfallConfigMissingConfigFile(t *testing.T) {
+	apiDetector := nightfallAPI.API_KEY
+	cryptoDetector := nightfallAPI.CRYPTOGRAPHIC_TOKEN
+	workspaceConfig, err := os.Getwd()
+	assert.NoError(t, err, "Unexpected error when getting current directory")
+	workspacePath := path.Join(workspaceConfig, "../../test/data")
+	expectedConfig := &nightfallconfig.NightfallConfigFileStructure{
+		Detectors:         []*nightfallAPI.Detector{&apiDetector, &cryptoDetector},
+		MaxNumberRoutines: 20,
+	}
+	actualConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, testMissingFileName, githublogger.NewDefaultGithubLogger())
 	assert.Equal(t, expectedConfig, actualConfig, "Incorrect nightfall config")
 }

--- a/internal/nightfallconfig/nightfall_config_test.go
+++ b/internal/nightfallconfig/nightfall_config_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	githublogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/github_logger"
-
 	"github.com/nightfallai/nightfall_code_scanner/internal/nightfallconfig"
 	nightfallAPI "github.com/nightfallai/nightfall_go_client/generated"
 	"github.com/stretchr/testify/assert"

--- a/internal/nightfallconfig/nightfall_config_test.go
+++ b/internal/nightfallconfig/nightfall_config_test.go
@@ -43,7 +43,7 @@ func TestGetNightfallConfigMissingConfigFile(t *testing.T) {
 	workspacePath := path.Join(workspaceConfig, "../../test/data")
 	expectedConfig := &nightfallconfig.NightfallConfigFileStructure{
 		Detectors:         []*nightfallAPI.Detector{&apiDetector, &cryptoDetector},
-		MaxNumberRoutines: 20,
+		MaxNumberRoutines: nightfallconfig.DefaultMaxNumberRoutines,
 	}
 	actualConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, testMissingFileName, githublogger.NewDefaultGithubLogger())
 	assert.Equal(t, expectedConfig, actualConfig, "Incorrect nightfall config")

--- a/internal/nightfallconfig/nightfall_config_test.go
+++ b/internal/nightfallconfig/nightfall_config_test.go
@@ -31,7 +31,8 @@ func TestGetNightfallConfig(t *testing.T) {
 		FileInclusionList:  []string{"*"},
 		FileExclusionList:  []string{".nightfalldlp/config.json"},
 	}
-	actualConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, testFileName, nil)
+	actualConfig, err := nightfallconfig.GetNightfallConfigFile(workspacePath, testFileName, nil)
+	assert.NoError(t, err, "Unexpected error in test GetNightfallConfig")
 	assert.Equal(t, expectedConfig, actualConfig, "Incorrect nightfall config")
 }
 
@@ -45,6 +46,7 @@ func TestGetNightfallConfigMissingConfigFile(t *testing.T) {
 		Detectors:         []*nightfallAPI.Detector{&apiDetector, &cryptoDetector},
 		MaxNumberRoutines: nightfallconfig.DefaultMaxNumberRoutines,
 	}
-	actualConfig := nightfallconfig.GetNightfallConfigFile(workspacePath, testMissingFileName, githublogger.NewDefaultGithubLogger())
+	actualConfig, err := nightfallconfig.GetNightfallConfigFile(workspacePath, testMissingFileName, githublogger.NewDefaultGithubLogger())
+	assert.NoError(t, err, "Unexpected error in test GetNightfallConfigMissingConfigFile")
 	assert.Equal(t, expectedConfig, actualConfig, "Incorrect nightfall config")
 }


### PR DESCRIPTION
https://nightfall.atlassian.net/jira/software/projects/NIGH/boards/19?selectedIssue=NIGH-154

Use default detectors (API_KEY and CRYTOGRAPHIC_TOKEN) when config file is missing/invalid.

Added to the github service as well, in case we want to allow this functionality there too.