### PR TITLE
Configure Base URL for Github Client

### DIFF
--- a/.github/workflows/nightfalldlp.yml
+++ b/.github/workflows/nightfalldlp.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Add $GOPATH/bin
         run: |
-          echo ::add-path::$(go env GOPATH)/bin
+          echo $(go env GOPATH)/bin >> $GITHUB_PATH
 
       - name: Download repo
         uses: actions/checkout@v2

--- a/cmd/nightfalldlp/main.go
+++ b/cmd/nightfalldlp/main.go
@@ -17,7 +17,7 @@ const (
 	nightfallConfigFileName = ".nightfalldlp/config.json"
 	githubActionsEnvVar     = "GITHUB_ACTIONS"
 	githubTokenEnvVar       = "GITHUB_TOKEN"
-	githubBaseUrlEnvVar     = "BASE_URL"
+	githubApiBaseUrlEnvVar  = "GITHUB_API_BASE_URL"
 	circleCiEnvVar          = "CIRCLECI"
 )
 
@@ -82,13 +82,13 @@ func usingCircleCi() bool {
 // CreateDiffReviewerClient determines the current environment that is running nightfalldlp
 // and returns the corresponding DiffReviewer client
 func CreateDiffReviewerClient() (diffreviewer.DiffReviewer, error) {
+	baseUrl, _ := os.LookupEnv(githubApiBaseUrlEnvVar)
 	switch {
 	case usingGithubAction():
 		githubToken, ok := os.LookupEnv(githubTokenEnvVar)
 		if !ok {
 			return nil, fmt.Errorf("could not find required %s environment variable", githubTokenEnvVar)
 		}
-		baseUrl, _ := os.LookupEnv(githubBaseUrlEnvVar)
 		return github.NewAuthenticatedGithubService(githubToken, baseUrl), nil
 	case usingCircleCi():
 		githubToken, ok := os.LookupEnv(githubTokenEnvVar)
@@ -97,7 +97,6 @@ func CreateDiffReviewerClient() (diffreviewer.DiffReviewer, error) {
 			circleService.GetLogger().Info("Github Token not found - findings will only be posted to CircleCI UI")
 			return circleService, nil
 		}
-		baseUrl, _ := os.LookupEnv(githubBaseUrlEnvVar)
 		return circleci.NewCircleCiServiceWithGithubComments(githubToken, baseUrl), nil
 	default:
 		return nil, errors.New("current environment unknown")

--- a/cmd/nightfalldlp/main.go
+++ b/cmd/nightfalldlp/main.go
@@ -88,10 +88,7 @@ func CreateDiffReviewerClient() (diffreviewer.DiffReviewer, error) {
 		if !ok {
 			return nil, fmt.Errorf("could not find required %s environment variable", githubTokenEnvVar)
 		}
-		baseUrl, ok := os.LookupEnv(githubBaseUrlEnvVar)
-		if !ok {
-			baseUrl = ""
-		}
+		baseUrl, _ := os.LookupEnv(githubBaseUrlEnvVar)
 		return github.NewAuthenticatedGithubService(githubToken, baseUrl), nil
 	case usingCircleCi():
 		githubToken, ok := os.LookupEnv(githubTokenEnvVar)
@@ -100,10 +97,7 @@ func CreateDiffReviewerClient() (diffreviewer.DiffReviewer, error) {
 			circleService.GetLogger().Info("Github Token not found - findings will only be posted to CircleCI UI")
 			return circleService, nil
 		}
-		baseUrl, ok := os.LookupEnv(githubBaseUrlEnvVar)
-		if !ok {
-			baseUrl = ""
-		}
+		baseUrl, _ := os.LookupEnv(githubBaseUrlEnvVar)
 		return circleci.NewCircleCiServiceWithGithubComments(githubToken, baseUrl), nil
 	default:
 		return nil, errors.New("current environment unknown")

--- a/cmd/nightfalldlp/main.go
+++ b/cmd/nightfalldlp/main.go
@@ -17,6 +17,7 @@ const (
 	nightfallConfigFileName = ".nightfalldlp/config.json"
 	githubActionsEnvVar     = "GITHUB_ACTIONS"
 	githubTokenEnvVar       = "GITHUB_TOKEN"
+	githubBaseUrlEnvVar     = "BASE_URL"
 	circleCiEnvVar          = "CIRCLECI"
 )
 
@@ -87,7 +88,11 @@ func CreateDiffReviewerClient() (diffreviewer.DiffReviewer, error) {
 		if !ok {
 			return nil, fmt.Errorf("could not find required %s environment variable", githubTokenEnvVar)
 		}
-		return github.NewAuthenticatedGithubService(githubToken), nil
+		baseUrl, ok := os.LookupEnv(githubBaseUrlEnvVar)
+		if !ok {
+			baseUrl = ""
+		}
+		return github.NewAuthenticatedGithubService(githubToken, baseUrl), nil
 	case usingCircleCi():
 		githubToken, ok := os.LookupEnv(githubTokenEnvVar)
 		if !ok || githubToken == "" {
@@ -95,7 +100,11 @@ func CreateDiffReviewerClient() (diffreviewer.DiffReviewer, error) {
 			circleService.GetLogger().Info("Github Token not found - findings will only be posted to CircleCI UI")
 			return circleService, nil
 		}
-		return circleci.NewCircleCiServiceWithGithubComments(githubToken), nil
+		baseUrl, ok := os.LookupEnv(githubBaseUrlEnvVar)
+		if !ok {
+			baseUrl = ""
+		}
+		return circleci.NewCircleCiServiceWithGithubComments(githubToken, baseUrl), nil
 	default:
 		return nil, errors.New("current environment unknown")
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/mock v1.4.3
 	github.com/google/go-cmp v0.5.1 // indirect
-	github.com/google/go-github/v31 v31.0.0
+	github.com/google/go-github/v33 v33.0.0
 	github.com/google/uuid v1.1.2
 	github.com/nightfallai/nightfall_go_client v1.0.3
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github/v31 v31.0.0 h1:JJUxlP9lFK+ziXKimTCprajMApV1ecWD4NB6CCb0plo=
-github.com/google/go-github/v31 v31.0.0/go.mod h1:NQPZol8/1sMoWYGN2yaALIBytu17gAWfhbweiEed3pM=
+github.com/google/go-github/v33 v33.0.0 h1:qAf9yP0qc54ufQxzwv+u9H0tiVOnPJxo0lI/JXqw3ZM=
+github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=

--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/diffutils"
 	gc "github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/github"

--- a/internal/clients/diffreviewer/circleci/circleci_service.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service.go
@@ -63,9 +63,9 @@ func NewCircleCiService() diffreviewer.DiffReviewer {
 }
 
 // NewCircleCiServiceWithGithubComments creates a new CircleCi service with an authenticated Github client
-func NewCircleCiServiceWithGithubComments(token string) diffreviewer.DiffReviewer {
+func NewCircleCiServiceWithGithubComments(token, baseUrl string) diffreviewer.DiffReviewer {
 	return &Service{
-		GithubClient: gc.NewAuthenticatedClient(token),
+		GithubClient: gc.NewAuthenticatedClient(token, baseUrl),
 		Logger:       circlelogger.NewDefaultCircleLogger(),
 	}
 }

--- a/internal/clients/diffreviewer/circleci/circleci_service_test.go
+++ b/internal/clients/diffreviewer/circleci/circleci_service_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	circlelogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/circle_logger"
 	"github.com/nightfallai/nightfall_code_scanner/internal/mocks/clients/gitdiff_mock"

--- a/internal/clients/diffreviewer/github/github_client.go
+++ b/internal/clients/diffreviewer/github/github_client.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"context"
+	"net/url"
+	"strings"
 
 	"github.com/google/go-github/v31/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/githubintf"
@@ -14,13 +16,24 @@ type Client struct {
 }
 
 // NewAuthenticatedClient generates an authenticated github client
-func NewAuthenticatedClient(token string) *Client {
+func NewAuthenticatedClient(token string, baseUrl string) *Client {
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
 	tc := oauth2.NewClient(ctx, ts)
 	githubClient := github.NewClient(tc)
+	// for enterprise
+	if baseUrl != "" {
+		u, _ := url.Parse(baseUrl)
+		if !strings.HasSuffix(u.Path, "/") {
+			u.Path += "/"
+		}
+		if !strings.HasSuffix(u.Path, "/api/v3/") {
+			u.Path += "api/v3/"
+		}
+		githubClient.BaseURL = u
+	}
 	return &Client{githubClient}
 }
 

--- a/internal/clients/diffreviewer/github/github_client.go
+++ b/internal/clients/diffreviewer/github/github_client.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/interfaces/githubintf"
 	"golang.org/x/oauth2"
 )

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/diffutils"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/gitdiff"

--- a/internal/clients/diffreviewer/github/github_service.go
+++ b/internal/clients/diffreviewer/github/github_service.go
@@ -128,9 +128,9 @@ type Service struct {
 }
 
 // NewAuthenticatedGithubService creates a new authenticated github service with the github token
-func NewAuthenticatedGithubService(githubToken string) diffreviewer.DiffReviewer {
+func NewAuthenticatedGithubService(githubToken, baseURL string) diffreviewer.DiffReviewer {
 	return &Service{
-		Client: NewAuthenticatedClient(githubToken),
+		Client: NewAuthenticatedClient(githubToken, baseURL),
 		Logger: githublogger.NewDefaultGithubLogger(),
 	}
 }
@@ -280,7 +280,7 @@ func (s *Service) WriteComments(comments []*diffreviewer.Comment) error {
 			Summary:     github.String(summaryNumFindings),
 			Annotations: remainingAnnotations,
 			Images: []*github.CheckRunImage{
-				&github.CheckRunImage{
+				{
 					Alt:      github.String(imageAlt),
 					ImageURL: github.String(imageURL),
 				},

--- a/internal/clients/diffreviewer/github/github_service_test.go
+++ b/internal/clients/diffreviewer/github/github_service_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer"
 	githubservice "github.com/nightfallai/nightfall_code_scanner/internal/clients/diffreviewer/github"
 	githublogger "github.com/nightfallai/nightfall_code_scanner/internal/clients/logger/github_logger"

--- a/internal/interfaces/githubintf/github_checks.go
+++ b/internal/interfaces/githubintf/github_checks.go
@@ -3,7 +3,7 @@ package githubintf
 import (
 	"context"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v33/github"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -destination=../../mocks/clients/githubchecks_mock/githubchecks_mock.go -source=../githubintf/github_checks.go -package=githubchecks_mock -mock_names=GithubChecks=GithubChecks

--- a/internal/interfaces/githubintf/github_pullrequests.go
+++ b/internal/interfaces/githubintf/github_pullrequests.go
@@ -3,7 +3,7 @@ package githubintf
 import (
 	"context"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v33/github"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -destination=../../mocks/clients/githubpullrequests_mock/githubpullrequests_mock.go -source=../githubintf/github_pullrequests.go -package=githubpullrequests_mock -mock_names=GithubPullRequests=GithubPullRequests

--- a/internal/interfaces/githubintf/github_repositories.go
+++ b/internal/interfaces/githubintf/github_repositories.go
@@ -3,7 +3,7 @@ package githubintf
 import (
 	"context"
 
-	"github.com/google/go-github/v31/github"
+	"github.com/google/go-github/v33/github"
 )
 
 //go:generate go run github.com/golang/mock/mockgen -destination=../../mocks/clients/githubrepositories_mock/githubrepositories_mock.go -source=../githubintf/github_repositories.go -package=githubrepositories_mock -mock_names=GithubRepositories=GithubRepositories

--- a/internal/mocks/clients/githubchecks_mock/githubchecks_mock.go
+++ b/internal/mocks/clients/githubchecks_mock/githubchecks_mock.go
@@ -7,7 +7,7 @@ package githubchecks_mock
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v31/github"
+	github "github.com/google/go-github/v33/github"
 	reflect "reflect"
 )
 

--- a/internal/mocks/clients/githubpullrequests_mock/githubpullrequests_mock.go
+++ b/internal/mocks/clients/githubpullrequests_mock/githubpullrequests_mock.go
@@ -7,7 +7,7 @@ package githubpullrequests_mock
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v31/github"
+	github "github.com/google/go-github/v33/github"
 	reflect "reflect"
 )
 

--- a/internal/mocks/clients/githubrepositories_mock/githubrepositories_mock.go
+++ b/internal/mocks/clients/githubrepositories_mock/githubrepositories_mock.go
@@ -7,7 +7,7 @@ package githubrepositories_mock
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v31/github"
+	github "github.com/google/go-github/v33/github"
 	reflect "reflect"
 )
 

--- a/test/credit_card.txt
+++ b/test/credit_card.txt
@@ -1,2 +1,0 @@
-301-423-1234
-what's yo name what's yo numba

--- a/test/credit_card.txt
+++ b/test/credit_card.txt
@@ -1,0 +1,3 @@
+4242-4242-4242-4242
+
+spend away my life savings

--- a/test/credit_card.txt
+++ b/test/credit_card.txt
@@ -1,3 +1,2 @@
-4242-4242-4242-4242
-
-spend away my life savings
+301-423-1234
+what's yo name what's yo numba


### PR DESCRIPTION
adds the ability to write to a specified url instead of the default https://api.github.com/

Looking at https://github.com/google/go-github/issues/958, looks like the url needs to be suffixed by `/api/v3/`